### PR TITLE
The React client, when used with the apollo-express server, didn't work

### DIFF
--- a/graphql-subscriptions-react/src/components/CommentEditorView.js
+++ b/graphql-subscriptions-react/src/components/CommentEditorView.js
@@ -6,8 +6,8 @@ import PropTypes from "prop-types";
 
 const createComment = gql`
   mutation CreateCommentMutation($postId: ID!, $body: String!) {
-    createCommentAsync(postId: $postId, body: $body) {
-      process_id
+    createComment(postId: $postId, body: $body) {
+      id
     }
   }
 `;

--- a/graphql-subscriptions-react/src/components/PostEditorView.js
+++ b/graphql-subscriptions-react/src/components/PostEditorView.js
@@ -5,8 +5,8 @@ import './PostEditorView.css';
 
 const createPost = gql`
   mutation CreatePostMutation($title: String!, $body: String!) {
-    createPostAsync(title: $title, body: $body) {
-      process_id
+    createPost(title: $title, body: $body) {
+      id
     }
   }
 `;


### PR DESCRIPTION
Hi
I fixed the errors given by GrapQL about some misalignments between the client mutation/fields and the server schema.
I don't know which was the expected behavior and if the Rails version should be updated too... that's just what I've done to have the client running.
Thank you
Stefano